### PR TITLE
fix: added loading screen for render healthz

### DIFF
--- a/backend/app/routes/health_routes.py
+++ b/backend/app/routes/health_routes.py
@@ -5,3 +5,7 @@ health_bp = Blueprint('health', __name__)
 @health_bp.route('/health-check', methods=["GET"])
 def heath_check():
     return jsonify({'status':'Up'}), 200
+
+@health_bp.route('/api/healthz', methods = ["GET"])
+def send_healthz():
+    return jsonify({'status':'Up'}), 200

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -35,5 +35,6 @@ export const getAssignedCredits = () => api.get('/auditor/credits');
 export const auditCreditApi = (auditData) => api.patch(`/auditor/audit/${auditData["creditId"]}`, auditData);
 export const checkAuditorsNumber = (amount) => api.get(`/NGO/audit-req`, { params: { amount } });
 export const getCreditDetailsAPI = (creditId) => api.get(`/buyer/credits/${creditId}`);
+export const getHealth = () => api.get('/healthz');
 
 export default api;


### PR DESCRIPTION
This PR deals with the issue of Uptime Robot. As it is seen that Render as a cloud service provider provides a loading screen while the web service is getting started (as it is serverless) but the front end is deployed over Vercel and so Render is not capable of doing so.
Therefore this PR adds a `healthz` route which will respond with a `200` when the service is up and so the loading screen will navigate to `/home` thereby showing the viewer that the web service is working just fine but the delayed action is because of the server-less nature of Render